### PR TITLE
Fix: Status LED now blinks on image capture from both RF and backup buttons

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -1,0 +1,79 @@
+# -*- coding: windows-1252 -*-
+#!/usr/bin/env python3
+
+import os
+import datetime
+import time
+from picamera2 import Picamera2
+from picamera2.previews.qt import QGlPicamera2
+from led_handler import led_status_blink  # ? Correct blink import
+
+class Camera:
+    def __init__(self):
+        self.picam2 = Picamera2()
+        self.preview_widget = None
+        self.preview_started = False
+        self.image_counter = 1
+        os.makedirs("Images", exist_ok=True)
+
+    def apply_video_transform(self, hflip=False, vflip=False, rotation=0, width=1920, height=1080):
+        """
+        Apply transformation settings for video recording with 1080p resolution.
+        """
+        config = self.picam2.create_video_configuration(main={"size": (width, height)})
+        config["transform"] = {"hflip": hflip, "vflip": vflip, "rotation": rotation}
+        self.picam2.configure(config)
+
+    def start_preview(self):
+        """
+        Start the camera preview using Qt OpenGL widget (1080p preview).
+        """
+        if self.preview_started:
+            return self.preview_widget
+
+        self.preview_widget = QGlPicamera2(self.picam2, keep_ar=True)
+
+        # Use 1080p for preview (better performance for video)
+        config = self.picam2.create_preview_configuration(main={"size": (1920, 1080)})
+        self.picam2.configure(config)
+
+        self.picam2.start()
+        self.preview_started = True
+        return self.preview_widget
+
+    def stop_preview(self):
+        if self.preview_started:
+            self.picam2.stop()
+            self.preview_started = False
+
+    def capture_image(self, media_category="general"):
+        """
+        Capture an image using max resolution (3280x2464).
+        """
+        sanitized_category = media_category.replace(" ", "_").lower()
+        now = datetime.datetime.now()
+        date_str = now.strftime("%d%b%Y").lower()
+        time_str = now.strftime("%H%M%S")
+        filename = os.path.join("Images", f"img_{self.image_counter}_{date_str}_{time_str}_{sanitized_category}.jpg")
+
+        try:
+            # Configure camera for max still resolution
+            still_config = self.picam2.create_still_configuration(main={"size": (3280, 2464)})
+            self.picam2.configure(still_config)
+            self.picam2.start()
+            time.sleep(0.2)  # Allow time for camera to warm up
+            self.picam2.capture_file(filename)
+
+            led_status_blink()  # ? Blink LED after capture
+        except Exception as e:
+            raise Exception("Capture failed: " + str(e))
+
+        self.image_counter += 1
+        return filename
+
+    def update_controls(self, controls):
+        normalized_controls = {key: value / 100.0 for key, value in controls.items()}
+        try:
+            self.picam2.set_controls(normalized_controls)
+        except Exception as e:
+            print("Error updating camera controls:", e)

--- a/gpio_handler.py
+++ b/gpio_handler.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import RPi.GPIO as GPIO
+import time
+import threading
+import os
+from led_handler import setup_leds
+
+class GPIOHandler:
+    def __init__(self, main_window):
+        self.main_window = main_window
+        setup_leds()
+
+        # GPIO mapping for both RF remote and backup physical buttons
+        self.pin_to_action = {
+            # RF Remote (YK04)
+            22: self.main_window.toggle_audio_recording,     # RF Button A
+            17: self.main_window.toggle_video_recording,     # RF Button B
+            23: self.main_window.handle_capture_image,       # RF Button C
+            27: self.shutdown_pi,                            # RF Button D
+
+            # Backup Physical Buttons (new GPIOs)
+            6:  self.main_window.toggle_audio_recording,     # Backup Button 1 (Pin 31)
+            13: self.main_window.toggle_video_recording,     # Backup Button 2 (Pin 33)
+            12: self.main_window.handle_capture_image        # Backup Button 3 (Pin 32)
+        }
+
+        self.rf_pins = [22, 17, 23, 27]
+        self.backup_pins = [6, 13, 12]
+
+        GPIO.setmode(GPIO.BCM)
+
+        # Set correct pull-up/down for each type
+        for pin in self.rf_pins:
+            GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+
+        for pin in self.backup_pins:
+            GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+        self.running = True
+        self.poll_thread = threading.Thread(target=self.poll_gpio, daemon=True)
+        self.poll_thread.start()
+
+    def poll_gpio(self):
+        last_state = {pin: GPIO.input(pin) for pin in self.pin_to_action}
+        while self.running:
+            for pin, action in self.pin_to_action.items():
+                current_state = GPIO.input(pin)
+                print(f"[GPIO DEBUG] Pin {pin}: {'HIGH' if current_state else 'LOW'}")
+
+                # Detect press based on pin type
+                if (
+                    (pin in self.rf_pins and current_state == GPIO.HIGH and last_state[pin] == GPIO.LOW) or
+                    (pin in self.backup_pins and current_state == GPIO.LOW and last_state[pin] == GPIO.HIGH)
+                ):
+                    try:
+                        print(f"[GPIO] Button press detected on pin {pin}")
+                        action()
+                    except Exception as e:
+                        print(f"[GPIO] Error on pin {pin}: {e}")
+                    time.sleep(0.3)  # Debounce
+
+                last_state[pin] = current_state
+            time.sleep(0.05)
+
+    def shutdown_pi(self):
+        print("[GPIO] Shutdown initiated via RF remote.")
+        os.system("sudo shutdown now")
+
+    def cleanup(self):
+        self.running = False
+        self.poll_thread.join()
+        GPIO.cleanup()

--- a/led_handler.py
+++ b/led_handler.py
@@ -1,0 +1,45 @@
+import RPi.GPIO as GPIO
+import time
+
+# Define GPIOs
+LED_STATUS = 5     # Camera Status LED
+LED_AUDIO = 19     # Audio Recording LED
+LED_RECORD = 26    # Video Recording LED
+
+def setup_leds():
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(LED_STATUS, GPIO.OUT)
+    GPIO.setup(LED_AUDIO, GPIO.OUT)
+    GPIO.setup(LED_RECORD, GPIO.OUT)
+
+    # Set initial states
+    GPIO.output(LED_STATUS, GPIO.HIGH)   # Status ON at start
+    GPIO.output(LED_AUDIO, GPIO.LOW)     # Audio OFF
+    GPIO.output(LED_RECORD, GPIO.LOW)    # Record OFF
+
+def led_status_on():
+    GPIO.output(LED_STATUS, GPIO.HIGH)
+
+def led_status_off():
+    GPIO.output(LED_STATUS, GPIO.LOW)
+
+def led_record_on():
+    GPIO.output(LED_RECORD, GPIO.HIGH)
+
+def led_record_off():
+    GPIO.output(LED_RECORD, GPIO.LOW)
+
+def led_audio_on():
+    GPIO.output(LED_AUDIO, GPIO.HIGH)
+
+def led_audio_off():
+    GPIO.output(LED_AUDIO, GPIO.LOW)
+
+def led_status_blink(duration=0.2):
+    current_state = GPIO.input(LED_STATUS)
+    GPIO.output(LED_STATUS, not current_state)
+    time.sleep(duration)
+    GPIO.output(LED_STATUS, current_state)
+
+def cleanup_leds():
+    GPIO.cleanup([LED_STATUS, LED_AUDIO, LED_RECORD])

--- a/main.py
+++ b/main.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+import sys
+import threading
+import os
+import datetime
+from PyQt5.QtWidgets import (
+    QApplication, QMainWindow, QWidget,
+    QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QCheckBox, QComboBox,
+    QDialog, QSlider, QDialogButtonBox
+)
+from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
+from camera import Camera
+from recorder import AudioRecorder, VideoRecorder
+from uploader import upload_image, upload_audio, upload_video
+from gpio_handler import GPIOHandler
+from utils import FAILED_IMAGES_DIR, FAILED_VIDEOS_DIR, FAILED_AUDIOS_DIR, speak  # <- speak added
+
+class AdvancedOptionsDialog(QDialog):
+    def __init__(self, camera, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Advanced Camera Settings")
+        self.camera = camera
+        self.init_ui()
+
+    def init_ui(self):
+        layout = QVBoxLayout(self)
+
+        self.brightness_label = QLabel("Brightness:")
+        self.brightness_slider = QSlider(Qt.Horizontal)
+        self.brightness_slider.setRange(0, 100)
+        self.brightness_slider.setValue(50)
+        self.brightness_slider.valueChanged.connect(self.update_camera_controls)
+        layout.addWidget(self.brightness_label)
+        layout.addWidget(self.brightness_slider)
+
+        self.sharpness_label = QLabel("Sharpness:")
+        self.sharpness_slider = QSlider(Qt.Horizontal)
+        self.sharpness_slider.setRange(0, 100)
+        self.sharpness_slider.setValue(50)
+        self.sharpness_slider.valueChanged.connect(self.update_camera_controls)
+        layout.addWidget(self.sharpness_label)
+        layout.addWidget(self.sharpness_slider)
+
+        self.contrast_label = QLabel("Contrast:")
+        self.contrast_slider = QSlider(Qt.Horizontal)
+        self.contrast_slider.setRange(0, 100)
+        self.contrast_slider.setValue(50)
+        self.contrast_slider.valueChanged.connect(self.update_camera_controls)
+        layout.addWidget(self.contrast_label)
+        layout.addWidget(self.contrast_slider)
+
+        self.saturation_label = QLabel("Saturation:")
+        self.saturation_slider = QSlider(Qt.Horizontal)
+        self.saturation_slider.setRange(0, 100)
+        self.saturation_slider.setValue(50)
+        self.saturation_slider.valueChanged.connect(self.update_camera_controls)
+        layout.addWidget(self.saturation_label)
+        layout.addWidget(self.saturation_slider)
+
+        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+    def update_camera_controls(self):
+        brightness = self.brightness_slider.value()
+        controls = {"Brightness": brightness}
+        self.camera.update_controls(controls)
+
+
+class MainWindow(QMainWindow):
+    imageCaptured = pyqtSignal(str)
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Construction Site Helmet - Preview")
+        self.showFullScreen()
+
+        self.imageCaptured.connect(self.finish_capture)
+
+        self.camera = Camera()
+        self.preview_widget = self.camera.start_preview()
+
+        self.audio_recorder = AudioRecorder()
+        self.video_recorder = VideoRecorder(self.camera, self.audio_recorder)
+        self.audio_recording = False
+        self.video_recording = False
+
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+        main_layout = QVBoxLayout(central_widget)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.setSpacing(0)
+
+        main_layout.addWidget(self.preview_widget, stretch=1)
+
+        bottom_layout = QHBoxLayout()
+        bottom_layout.setSpacing(10)
+
+        self.type_dropdown = QComboBox()
+        categories = ["General", "Electrical", "Plumbing", "HVAC", "Patrician", 
+                      "Loose furniture", "Light fixtures", "Flooring", "Ceiling", "Painting"]
+        self.type_dropdown.addItems(categories)
+        bottom_layout.addWidget(self.type_dropdown)
+
+        self.video_btn = QPushButton("Start Video")
+        self.video_btn.setFixedSize(150, 40)
+        self.video_btn.clicked.connect(self.toggle_video_recording)
+        bottom_layout.addWidget(self.video_btn)
+
+        self.record_audio_checkbox = QCheckBox("Record Audio with Video")
+        self.record_audio_checkbox.setChecked(True)
+        bottom_layout.addWidget(self.record_audio_checkbox)
+
+        self.capture_btn = QPushButton("Capture Image")
+        self.capture_btn.setFixedSize(150, 40)
+        self.capture_btn.clicked.connect(self.handle_capture_image)
+        bottom_layout.addWidget(self.capture_btn)
+
+        self.audio_btn = QPushButton("Start Audio")
+        self.audio_btn.setFixedSize(150, 40)
+        self.audio_btn.clicked.connect(self.toggle_audio_recording)
+        bottom_layout.addWidget(self.audio_btn)
+
+        self.advanced_btn = QPushButton("Advanced Options")
+        self.advanced_btn.setFixedSize(150, 40)
+        self.advanced_btn.clicked.connect(self.open_advanced_options)
+        bottom_layout.addWidget(self.advanced_btn)
+
+        bottom_layout.addStretch()
+
+        self.close_btn = QPushButton("Close Session")
+        self.close_btn.setFixedSize(150, 40)
+        self.close_btn.clicked.connect(self.close_session)
+        bottom_layout.addWidget(self.close_btn)
+
+        main_layout.addLayout(bottom_layout)
+
+        self.status_label = QLabel("Ready")
+        self.status_label.setAlignment(Qt.AlignCenter)
+        self.status_label.setStyleSheet("background-color: #EFEFEF; padding: 5px;")
+        main_layout.addWidget(self.status_label)
+
+        self.gpio_handler = GPIOHandler(self)
+        self.attempt_reupload_failed_files()
+
+    def open_advanced_options(self):
+        dialog = AdvancedOptionsDialog(self.camera, self)
+        dialog.exec_()
+
+    def attempt_reupload_failed_files(self):
+        failed_dirs = {
+            "image": FAILED_IMAGES_DIR,
+            "audio": FAILED_AUDIOS_DIR,
+            "video": FAILED_VIDEOS_DIR,
+        }
+        for file_type, failed_dir in failed_dirs.items():
+            if not os.path.exists(failed_dir):
+                continue
+            for file_name in os.listdir(failed_dir):
+                file_path = os.path.join(failed_dir, file_name)
+                print(f"Attempting re-upload of {file_path}")
+                if file_type == "image":
+                    success, resp = upload_image(file_path, "", "")
+                elif file_type == "audio":
+                    success, resp = upload_audio(file_path, "", "")
+                elif file_type == "video":
+                    success, resp = upload_video(file_path, "", "")
+                if success:
+                    os.remove(file_path)
+                    print(f"Successfully re-uploaded and deleted {file_path}")
+                else:
+                    print(f"Failed again to upload {file_path}: {resp}")
+
+    def handle_capture_image(self):
+        self.capture_btn.setEnabled(False)
+        threading.Thread(target=self.capture_image_worker, daemon=True).start()
+
+    def capture_image_worker(self):
+        msg = ""
+        try:
+            speak("Capturing image")
+            category = self.type_dropdown.currentText().lower()
+            capture_time = datetime.datetime.now().strftime("%H:%M:%S")
+            image_path = self.camera.capture_image(category)
+            success, resp = upload_image(image_path, capture_time, capture_time)
+            if success:
+                os.remove(image_path)
+                msg = f"Image captured & uploaded: {image_path}"
+                speak("Image captured")
+            else:
+                msg = f"Image captured but upload failed: {resp}"
+                speak("Image upload failed")
+        except Exception as e:
+            msg = f"Image capture error: {e}"
+            speak("Image capture failed")
+        finally:
+            self.imageCaptured.emit(msg)
+
+    @pyqtSlot(str)
+    def finish_capture(self, msg):
+        self.status_label.setText(msg)
+        self.capture_btn.setEnabled(True)
+
+    def toggle_audio_recording(self):
+        if not self.audio_recording:
+            self.audio_recorder.start_recording()
+            self.audio_recording = True
+            self.audio_btn.setText("Stop Audio")
+            self.status_label.setText("Audio recording started...")
+            speak("Audio recording started")
+        else:
+            category = self.type_dropdown.currentText().lower()
+            audio_file, start_time, end_time = self.audio_recorder.stop_recording(category)
+            self.audio_recording = False
+            self.audio_btn.setText("Start Audio")
+            success, resp = upload_audio(audio_file, start_time, end_time)
+            if success:
+                os.remove(audio_file)
+                self.status_label.setText(f"Audio recorded & uploaded: {audio_file}")
+            else:
+                self.status_label.setText(f"Audio recorded but upload failed: {resp}")
+            speak("Audio recording stopped")
+
+    def toggle_video_recording(self):
+        record_audio_with_video = self.record_audio_checkbox.isChecked()
+        self.attempt_reupload_failed_files()
+        category = self.type_dropdown.currentText().lower()
+        if not self.video_recording:
+            self.video_recorder.start_recording(with_audio=record_audio_with_video)
+            self.video_recording = True
+            self.video_btn.setText("Stop Video")
+            self.status_label.setText("Video recording started...")
+            speak("Video recording started")
+        else:
+            segments = self.video_recorder.stop_recording(category)
+            self.video_recording = False
+            self.video_btn.setText("Start Video")
+            if segments:
+                msg_list = []
+                for seg in segments:
+                    seg_file = seg["file"]
+                    start_time = seg["start"]
+                    end_time = seg["end"]
+                    success, resp = upload_video(seg_file, start_time, end_time)
+                    if success:
+                        os.remove(seg_file)
+                        msg_list.append(seg_file)
+                    else:
+                        msg_list.append(f"{seg_file} (upload failed)")
+                self.status_label.setText("Video segments recorded: " + ", ".join(msg_list))
+            else:
+                self.status_label.setText("No video segments recorded.")
+            speak("Video recording stopped")
+
+    def close_session(self):
+        self.camera.stop_preview()
+        if self.audio_recording:
+            self.audio_recorder.stop_recording(self.type_dropdown.currentText().lower())
+        if self.video_recording:
+            self.video_recorder.stop_recording(self.type_dropdown.currentText().lower())
+        self.gpio_handler.cleanup()
+        QApplication.quit()
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec_())

--- a/merger.py
+++ b/merger.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import subprocess
+
+def merge_audio_video(video_file, audio_file, output_file):
+    """
+    Merges the given video file and audio file into a single output file using ffmpeg.
+    
+    Parameters:
+      video_file (str): Path to the video file.
+      audio_file (str): Path to the audio file.
+      output_file (str): Path where the merged file should be saved.
+      
+    Returns:
+      bool: True if merging is successful, False otherwise.
+    """
+    cmd = [
+        "ffmpeg",
+        "-y",               # Overwrite output if exists.
+        "-i", video_file,   # Input video.
+        "-i", audio_file,   # Input audio.
+        "-c:v", "copy",     # Copy the video stream without re-encoding.
+        "-c:a", "aac",      # Encode the audio to AAC.
+        output_file
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+        print(f"Merged {video_file} and {audio_file} into {output_file}")
+        return True
+    except subprocess.CalledProcessError as e:
+        print("ffmpeg merge error:", e)
+        return False
+
+if __name__ == '__main__':
+    # Example test: This code will only run if you execute merger.py directly.
+    video_file = "Videos/test_video.mp4"
+    audio_file = "Audios/test_audio.wav"
+    output_file = "Videos/test_merged.mp4"
+    merge_audio_video(video_file, audio_file, output_file)

--- a/recorder.py
+++ b/recorder.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+import pyaudio
+import wave
+import threading
+import datetime
+import os
+import time
+import subprocess
+
+# 🔁 Import LED control for recording indication
+from led_handler import led_record_on, led_record_off, led_audio_on, led_audio_off
+
+# Audio settings
+CHUNK = 1024
+FORMAT = pyaudio.paInt16
+CHANNELS = 1
+RATE = 44100
+
+class AudioRecorder:
+    def __init__(self):
+        os.makedirs("Audios", exist_ok=True)
+        self.audio_thread = None
+        self.stop_event = None
+        self.temp_audio_file = os.path.join("Audios", "temp_audio.wav")
+        self.recording_start_time = None
+        self.audio_counter = 1
+        self.segment_audio_thread = None
+        self.segment_stop_event = None
+        self.segment_temp_file = None
+        self.segment_start_time = None
+
+    def start_recording(self):
+        if self.audio_thread and self.audio_thread.is_alive():
+            return
+        self.stop_event = threading.Event()
+        self.recording_start_time = datetime.datetime.now()
+        self.audio_thread = threading.Thread(target=self.record_audio, daemon=True)
+        self.audio_thread.start()
+        led_audio_on()  # Turn on audio LED
+
+    def record_audio(self):
+        p = pyaudio.PyAudio()
+        stream = p.open(format=FORMAT, channels=CHANNELS, rate=RATE,
+                        input=True, frames_per_buffer=CHUNK)
+        frames = []
+        while not self.stop_event.is_set():
+            try:
+                data = stream.read(CHUNK, exception_on_overflow=False)
+            except Exception as e:
+                print("Audio error:", e)
+                continue
+            frames.append(data)
+        stream.stop_stream()
+        stream.close()
+        p.terminate()
+        wf = wave.open(self.temp_audio_file, 'wb')
+        wf.setnchannels(CHANNELS)
+        wf.setsampwidth(p.get_sample_size(FORMAT))
+        wf.setframerate(RATE)
+        wf.writeframes(b''.join(frames))
+        wf.close()
+
+    def stop_recording(self, media_category):
+        if self.stop_event:
+            self.stop_event.set()
+        if self.audio_thread:
+            self.audio_thread.join()
+
+        led_audio_off()  # Turn off audio LED
+
+        start = self.recording_start_time.strftime("%d%b%Y_%H%M%S").lower()
+        end_time = datetime.datetime.now()
+        end = end_time.strftime("%d%b%Y_%H%M%S").lower()
+        start_hms = self.recording_start_time.strftime("%H:%M:%S")
+        end_hms = end_time.strftime("%H:%M:%S")
+
+        final_filename = os.path.join("Audios", f"audio_{self.audio_counter}_{start}_to_{end}_{media_category}.wav")
+
+        try:
+            os.rename(self.temp_audio_file, final_filename)
+        except Exception as e:
+            print("Error renaming audio file:", e)
+            final_filename = self.temp_audio_file
+
+        self.audio_counter += 1
+        return final_filename, start_hms, end_hms
+
+    def start_segmented_recording(self):
+        self.segment_stop_event = threading.Event()
+        self.segment_start_time = datetime.datetime.now()
+        self.segment_temp_file = os.path.join("Audios", "temp_seg_audio.wav")
+        self.segment_audio_thread = threading.Thread(target=self.record_segment_audio, daemon=True)
+        self.segment_audio_thread.start()
+
+    def record_segment_audio(self):
+        p = pyaudio.PyAudio()
+        stream = p.open(format=FORMAT, channels=CHANNELS, rate=RATE,
+                        input=True, frames_per_buffer=CHUNK)
+        frames = []
+        while not self.segment_stop_event.is_set():
+            try:
+                data = stream.read(CHUNK, exception_on_overflow=False)
+            except Exception as e:
+                print("Segmented audio error:", e)
+                continue
+            frames.append(data)
+        stream.stop_stream()
+        stream.close()
+        p.terminate()
+        wf = wave.open(self.segment_temp_file, 'wb')
+        wf.setnchannels(CHANNELS)
+        wf.setsampwidth(p.get_sample_size(FORMAT))
+        wf.setframerate(RATE)
+        wf.writeframes(b''.join(frames))
+        wf.close()
+
+    def stop_segmented_recording(self):
+        if self.segment_stop_event:
+            self.segment_stop_event.set()
+        if self.segment_audio_thread:
+            self.segment_audio_thread.join()
+        start = self.segment_start_time.strftime("%d%b%Y_%H%M%S").lower()
+        end_time = datetime.datetime.now()
+        end = end_time.strftime("%d%b%Y_%H%M%S").lower()
+        final_filename = os.path.join("Audios", f"audio_seg_{start}_to_{end}.wav")
+        try:
+            os.rename(self.segment_temp_file, final_filename)
+        except Exception as e:
+            print("Error renaming segmented audio file:", e)
+            final_filename = self.segment_temp_file
+        return final_filename
+
+class VideoRecorder:
+    def __init__(self, camera, audio_recorder=None):
+        self.camera = camera
+        self.audio_recorder = audio_recorder
+        self.recording = False
+        self.segment_threshold = 50 * 1024 * 1024
+        self.current_video_file = None
+        self.segments = []
+        self.monitor_thread = None
+        self.stop_monitor = False
+        self.with_audio = False
+        self.session_counter = 1
+        self.chunk_num = 1
+        self.video_start_time = None
+        self.segmentation_thread = None
+        self.current_segment_start = None
+
+    def generate_video_filename(self):
+        now = datetime.datetime.now()
+        date_str = now.strftime("%d%b%Y").lower()
+        time_str = now.strftime("%H%M%S")
+        return os.path.join("Videos", f"temp_vdo_{date_str}_{time_str}.mp4")
+
+    def start_recording(self, with_audio=False):
+        if self.recording:
+            return
+        self.recording = True
+        led_record_on()  # 🔁 Turn on LED when recording starts
+        self.with_audio = with_audio
+        self.segments.clear()
+        os.makedirs("Videos", exist_ok=True)
+
+        self.current_segment_start = datetime.datetime.now()
+
+        if self.with_audio and self.audio_recorder:
+            self.segmentation_thread = threading.Thread(
+                target=self._record_with_segmentation, daemon=True
+            )
+            self.segmentation_thread.start()
+        else:
+            self.current_video_file = self.generate_video_filename()
+            self.camera.apply_video_transform(hflip=True, vflip=False, rotation=90)
+            self.camera.picam2.start_and_record_video(self.current_video_file)
+
+            self.stop_monitor = False
+            self.monitor_thread = threading.Thread(target=self.monitor_video_size, daemon=True)
+            self.monitor_thread.start()
+
+    def monitor_video_size(self):
+        while self.recording and not self.stop_monitor:
+            if os.path.exists(self.current_video_file):
+                size = os.path.getsize(self.current_video_file)
+                if size >= self.segment_threshold:
+                    segment_end = datetime.datetime.now()
+                    try:
+                        self.camera.picam2.stop_recording()
+                    except Exception as e:
+                        print("Error stopping recording for segmentation:", e)
+
+                    segment_record = {
+                        "file": self.current_video_file,
+                        "start": self.current_segment_start.strftime("%H:%M:%S"),
+                        "end": segment_end.strftime("%H:%M:%S"),
+                        "start_str": self.current_segment_start.strftime("%d%b%Y_%H%M%S").lower(),
+                        "end_str": segment_end.strftime("%d%b%Y_%H%M%S").lower()
+                    }
+                    self.segments.append(segment_record)
+
+                    self.current_segment_start = segment_end
+                    self.current_video_file = self.generate_video_filename()
+                    self.camera.picam2.start_and_record_video(self.current_video_file)
+
+            time.sleep(1)
+
+    def _record_with_segmentation(self):
+        seg_start = self.current_segment_start
+        while self.recording:
+            video_file = self.generate_video_filename()
+            self.camera.picam2.start_and_record_video(video_file)
+            self.audio_recorder.start_segmented_recording()
+
+            while self.recording:
+                if os.path.exists(video_file) and os.path.getsize(video_file) >= self.segment_threshold:
+                    break
+                time.sleep(1)
+
+            self.camera.picam2.stop_recording()
+            seg_end = datetime.datetime.now()
+            audio_file = self.audio_recorder.stop_segmented_recording()
+
+            merged_file = self.merge_video_audio(video_file, audio_file, seg_start, seg_end, None)
+            if merged_file:
+                segment_record = {
+                    "file": merged_file,
+                    "start": seg_start.strftime("%H:%M:%S"),
+                    "end": seg_end.strftime("%H:%M:%S"),
+                    "start_str": seg_start.strftime("%d%b%Y_%H%M%S").lower(),
+                    "end_str": seg_end.strftime("%d%b%Y_%H%M%S").lower()
+                }
+                self.segments.append(segment_record)
+            else:
+                segment_record = {
+                    "file": video_file,
+                    "start": seg_start.strftime("%H:%M:%S"),
+                    "end": seg_end.strftime("%H:%M:%S"),
+                    "start_str": seg_start.strftime("%d%b%Y_%H%M%S").lower(),
+                    "end_str": seg_end.strftime("%d%b%Y_%H%M%S").lower()
+                }
+                self.segments.append(segment_record)
+
+            self.chunk_num += 1
+            seg_start = seg_end
+
+    def merge_video_audio(self, video_file, audio_file, seg_start, seg_end, media_category):
+        seg_start_str = seg_start.strftime("%d%b%Y_%H%M%S").lower()
+        seg_end_str = seg_end.strftime("%d%b%Y_%H%M%S").lower()
+        category_str = media_category if media_category else ""
+        merged_file = os.path.join(
+            "Videos",
+            f"merged_{self.session_counter}_{self.chunk_num}_{seg_start_str}_to_{seg_end_str}_{category_str}.mp4"
+        )
+        cmd = [
+            "ffmpeg", "-y",
+            "-i", video_file,
+            "-i", audio_file,
+            "-c:v", "copy",
+            "-c:a", "aac",
+            merged_file
+        ]
+        try:
+            subprocess.run(cmd, check=True)
+            os.remove(video_file)
+            os.remove(audio_file)
+            return merged_file
+        except subprocess.CalledProcessError as e:
+            print("Error during merging:", e)
+            return None
+
+    def stop_recording(self, media_category):
+        self.recording = False
+        led_record_off()  # 🔁 Turn off LED when recording ends
+
+        if self.with_audio and self.segmentation_thread is not None:
+            self.segmentation_thread.join()
+        else:
+            self.stop_monitor = True
+            if self.monitor_thread:
+                self.monitor_thread.join()
+
+            if self.current_video_file:
+                seg_end = datetime.datetime.now()
+                try:
+                    self.camera.picam2.stop_recording()
+                except Exception as e:
+                    print("Error stopping video recording on final segment:", e)
+
+                segment_record = {
+                    "file": self.current_video_file,
+                    "start": self.current_segment_start.strftime("%H:%M:%S"),
+                    "end": seg_end.strftime("%H:%M:%S"),
+                    "start_str": self.current_segment_start.strftime("%d%b%Y_%H%M%S").lower(),
+                    "end_str": seg_end.strftime("%d%b%Y_%H%M%S").lower()
+                }
+                self.segments.append(segment_record)
+
+        self.camera.picam2.start()
+
+        final_segments = []
+        prefix = "merged" if self.with_audio else "vdo"
+
+        for idx, seg in enumerate(self.segments, start=1):
+            final_name = os.path.join(
+                "Videos",
+                f"{prefix}_{self.session_counter}_{idx}_{seg['start_str']}_to_{seg['end_str']}_{media_category}.mp4"
+            )
+            try:
+                os.rename(seg["file"], final_name)
+            except Exception as e:
+                print("Error renaming video file:", e)
+                final_name = seg["file"]
+            final_segments.append({
+                "file": final_name,
+                "start": seg["start"],
+                "end": seg["end"]
+            })
+
+        self.session_counter += 1
+        self.chunk_num = 1
+        return final_segments

--- a/uploader.py
+++ b/uploader.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import os
+import requests
+import shutil
+from utils import FAILED_IMAGES_DIR, FAILED_VIDEOS_DIR, FAILED_AUDIOS_DIR
+from utils import get_rpi_serial
+
+DEVICE_ID = get_rpi_serial()
+# DEVICE_ID = "raspberry_pi_01"
+UPLOAD_URL = "https://centrix.co.in/v_api/upload"
+HEADERS = {"X-API-KEY": "DDjgMfxLqhxbNmaBoTkfBJkhMxNxkPwMgGjPUwCOaJRCBrvtUX"}
+
+def handle_failed_upload(file_path, file_type):
+    if not os.path.exists(file_path):
+        print(f"File {file_path} does not exist, cannot move.")
+        return
+    if file_type == "image":
+        target_dir = FAILED_IMAGES_DIR
+    elif file_type == "audio":
+        target_dir = FAILED_AUDIOS_DIR
+    elif file_type == "video":
+        target_dir = FAILED_VIDEOS_DIR
+    else:
+        return
+    os.makedirs(target_dir, exist_ok=True)
+    try:
+        shutil.move(file_path, os.path.join(target_dir, os.path.basename(file_path)))
+        print(f"Moved failed upload to {target_dir}")
+    except Exception as e:
+        print(f"Failed to move file {file_path}: {e}")
+
+def upload_file(file_path, file_type, start_time="", end_time=""):
+    try:
+        with open(file_path, "rb") as f:
+            files = {file_type: f}
+            data = {
+                "device_id": DEVICE_ID,
+                "file_type": file_type,
+                "start_time": start_time,
+                "end_time": end_time
+            }
+            resp = requests.post(UPLOAD_URL, headers=HEADERS, files=files, data=data)
+        if resp.status_code == 200:
+            result = resp.json()
+            if result.get("success"):
+                return True, result
+            else:
+                handle_failed_upload(file_path, file_type)
+                return False, result
+        else:
+            handle_failed_upload(file_path, file_type)
+            return False, {"error": resp.text}
+    except Exception as e:
+        handle_failed_upload(file_path, file_type)
+        return False, {"exception": str(e)}
+
+def upload_image(file_path, start_time="", end_time=""):
+    return upload_file(file_path, "video", start_time, end_time)
+
+def upload_video(file_path, start_time="", end_time=""):
+    return upload_file(file_path, "video", start_time, end_time)
+
+def upload_audio(file_path, start_time="", end_time=""):
+    return upload_file(file_path, "video", start_time, end_time)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import os
+import datetime
+import subprocess
+
+# Ensure required directories exist.
+IMAGES_DIR = "Images"
+os.makedirs(IMAGES_DIR, exist_ok=True)
+
+VIDEOS_DIR = "Videos"
+os.makedirs(VIDEOS_DIR, exist_ok=True)
+
+AUDIOS_DIR = "Audios"
+os.makedirs(AUDIOS_DIR, exist_ok=True)
+
+FAILED_DIR = "failed_to_upload"
+FAILED_IMAGES_DIR = os.path.join(FAILED_DIR, "Images")
+FAILED_VIDEOS_DIR = os.path.join(FAILED_DIR, "Videos")
+FAILED_AUDIOS_DIR = os.path.join(FAILED_DIR, "Audios")
+
+os.makedirs(FAILED_IMAGES_DIR, exist_ok=True)
+os.makedirs(FAILED_VIDEOS_DIR, exist_ok=True)
+os.makedirs(FAILED_AUDIOS_DIR, exist_ok=True)
+
+def format_timestamp():
+    return datetime.datetime.now().strftime("%d%b%y_%H%M%S").lower()
+
+def get_image_filename(device_id="helmet", prefix="img"):
+    ts = format_timestamp()
+    filename = os.path.join(IMAGES_DIR, f"{prefix}_{device_id}_{ts}.jpg")
+    return filename
+
+def get_video_filename(device_id="helmet", session_no=1, seg_num=1, prefix="vdo"):
+    ts = datetime.datetime.now().strftime("%d%b%y_%H%M%S").lower()
+    filename = os.path.join(VIDEOS_DIR, f"{prefix}_{device_id}_{session_no}_{seg_num}_{ts}.mp4")
+    return filename
+
+def get_rpi_serial():
+    try:
+        with open('/proc/cpuinfo', 'r') as f:
+            for line in f:
+                if line.startswith('Serial'):
+                    return line.strip().split(":")[1].strip()
+    except Exception as e:
+        print("Could not read RPi serial number:", e)
+    return "unknown_pi"
+
+def speak(text):
+    try:
+        # -s sets the speed (default is 175 WPM); use 130 for slower pace
+        subprocess.run(['espeak', '-s', '130', text], check=True)
+    except Exception as e:
+        print(f"[TTS ERROR] Failed to speak '{text}': {e}")
+


### PR DESCRIPTION
Previously, while main_window.handle_capture_image() successfully triggered image capture, the status LED did not blink as expected. This feedback was important to confirm that a capture occurred.

The issue was that the *led_status_blink()* function was not being explicitly called inside *handle_capture_image()*, and the LED state remained unchanged despite the image being taken.

